### PR TITLE
Correct import path for Go migrations

### DIFF
--- a/lib/goose/migration_go.go
+++ b/lib/goose/migration_go.go
@@ -104,7 +104,7 @@ import (
 	"encoding/gob"
 
 	_ "{{.Import}}"
-	"bitbucket.org/liamstask/goose/lib/goose"
+	"github.com/resonancelabs/goose/lib/goose"
 )
 
 func main() {


### PR DESCRIPTION
## Summary

We forked goose to remove the driver that weren't using that didn't build everywhere.  

Need to update the generated code for Go migrations to match the import path we're using in our repo.  (These import rewriting issues make me sad.)  This wasn't a problem before because I no one had tried making a Go migration before...
